### PR TITLE
Support for icons and nested components

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Transforms destructured imports of `@kiwicom/orbit-components` to granular ones!
 ## Setup
 
 Install:
-* `yarn add -D @kiwicom/babel-plugin-orbit-components`
+
+- `yarn add -D @kiwicom/babel-plugin-orbit-components`
 
 Then just add `@kiwicom/orbit-components` to the list of babel plugins, e.g. to `.babelrc`:
 
@@ -20,7 +21,7 @@ Then just add `@kiwicom/orbit-components` to the list of babel plugins, e.g. to 
 }
 ```
 
-### Example
+### Examples
 
 ```js
 // Input:
@@ -28,6 +29,14 @@ import { Alert } from "@kiwicom/orbit-components";
 
 // Output:
 import Alert from "@kiwicom/orbit-components/lib/Alert";
+```
+
+```js
+// Input
+import { Passengers } from "@kiwicom/orbit-components/lib/icons";
+
+// Output
+import Passengers from "@kiwicom/orbit-components/lib/icons/Passengers";
 ```
 
 ## License

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -24,6 +24,43 @@ const fromLib = `
 import Alert from "@kiwicom/orbit-components/lib/Alert";
 `;
 
+const nested = `
+import { ModalSection } from "@kiwicom/orbit-components";
+`;
+
+const nestedWant = `
+import ModalSection from "@kiwicom/orbit-components/lib/Modal/ModalSection";
+`;
+
+const nestedMulti = `
+import { Alert, ModalSection } from "@kiwicom/orbit-components";
+`;
+
+const nestedMultiWant = `
+import ModalSection from "@kiwicom/orbit-components/lib/Modal/ModalSection";
+import Alert from "@kiwicom/orbit-components/lib/Alert";
+`;
+
+const icon = `
+import { Passengers } from "@kiwicom/orbit-components/lib/icons";
+`;
+
+const iconWant = `
+import Passengers from "@kiwicom/orbit-components/lib/icons/Passengers";
+`;
+
+const mixed = `
+import { Alert, ModalSection } from "@kiwicom/orbit-components";
+import { Passengers, Invoice } from "@kiwicom/orbit-components/lib/icons";
+`;
+
+const mixedWant = `
+import ModalSection from "@kiwicom/orbit-components/lib/Modal/ModalSection";
+import Alert from "@kiwicom/orbit-components/lib/Alert";
+import Invoice from "@kiwicom/orbit-components/lib/icons/Invoice";
+import Passengers from "@kiwicom/orbit-components/lib/icons/Passengers";
+`;
+
 test(t => {
   const resSingle = babel.transform(single, { plugins: [plugin] });
   t.equals(resSingle.code, singleWant.trim());
@@ -33,6 +70,18 @@ test(t => {
 
   const resFromLib = babel.transform(fromLib, { plugins: [plugin] });
   t.equals(resFromLib.code, resFromLib.code.trim());
+
+  const resNested = babel.transform(nested, { plugins: [plugin] });
+  t.equals(resNested.code, nestedWant.trim());
+
+  const resNestedMulti = babel.transform(nestedMulti, { plugins: [plugin] });
+  t.equals(resNestedMulti.code, nestedMultiWant.trim());
+
+  const resIcon = babel.transform(icon, { plugins: [plugin] });
+  t.equals(resIcon.code, iconWant.trim());
+
+  const resMixed = babel.transform(mixed, { plugins: [plugin] });
+  t.equals(resMixed.code, mixedWant.trim());
 
   t.end();
 });


### PR DESCRIPTION
Added support for icons and nested components.

Example: ModalSection is located at
`"@kiwicom/orbit-components/lib/Modal/ModalSection"`
and not at
`"@kiwicom/orbit-components/lib/ModalSection"`
so the current master would fail.